### PR TITLE
Rework average inflation

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -182,13 +182,35 @@ export default class index extends Vue {
   }
 
   get averageInflation(): number {
-    const averageInflation: number = parseFloat((this.inflationPercentage / Math.abs(this.outputYear - this.inputYear)).toFixed(2))
+    const yearDifference: number = this.outputYear - this.inputYear
 
-    if (!averageInflation) {
+    if (yearDifference === 0) {
       return 0
     }
 
-    return averageInflation
+    let totalInflation: number = 0
+
+    let year: number = this.inputYear
+
+    for (let i: number = 0; i < Math.abs(yearDifference); i++) {
+      if (yearDifference > 0) {
+        year++
+      }
+
+      let yearData: YearData|undefined = this.getItemByDate(year + this.inputMonth)
+
+      if (!yearData) {
+        return 0
+      }
+
+      totalInflation += parseFloat(yearData!.JaarmutatieCPI_1!.replace(/\s/g, ''))
+
+      if (yearDifference < 0) {
+        year--
+      }
+    }
+
+    return this.round(totalInflation / yearDifference)
   }
 
   calculateCPIMutation(beginYear: number, endYear: number, month: string, conversion: boolean = true): number {


### PR DESCRIPTION
Previously the average inflation was calculated by dividing the total (compounding) inflation by the year difference. This however does not accurately represent the inflation per year as it is compounded and therefore over large periods will return huge inflation percentages. Now it's calculated by adding up all original inflation percentages and diving that by the year difference. This will give the user a more accurate representation.